### PR TITLE
Release/1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ node_modules
 .gradle
 .DS_Store
 build
+
+.idea/

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ group = no.bouvet
 projectName = app-cookie-panel
 vendorName = Bouvet
 vendorUrl = https://www.bouvet.no
-version = 1.1.0
+version = 1.2.0
 xpVersion = 7.9.0

--- a/src/frontend/scripts/cookie-panel.es6
+++ b/src/frontend/scripts/cookie-panel.es6
@@ -121,7 +121,7 @@
 
   const renderSettingsPanel = () => {
     const html = `
-      <div role="dialog" class="cookie-panel-settings" id="cookie-panel-settings" aria-labelledby="cookie-panel-settings-title">
+      <div role="dialog" class="cookie-panel-settings ${config.theme}" id="cookie-panel-settings" aria-labelledby="cookie-panel-settings-title">
         <div class="cookie-panel-settings__inner">
           <h2 id="cookie-panel-settings-title">${config.title}</h2>
           <div class="cookie-panel-settings__categories">${renderCategories(config.categories)}</div>

--- a/src/frontend/scripts/cookie-panel.es6
+++ b/src/frontend/scripts/cookie-panel.es6
@@ -32,8 +32,8 @@
 
   const setCookie = (name, value) => {
     const date = new Date();
-    date.setTime(date.getTime() + (365 * 24 * 60 * 60 * 1000));
-    document.cookie = `${name}=${value || ""}; Expires=${date.toUTCString()}; Max-Age=${365 * 24 * 60 * 60}; Path=/`;
+    date.setTime(date.getTime() + ((config.expireControlCookieAfterDays || 365) * 24 * 60 * 60 * 1000));
+    document.cookie = `${name}=${value || ""}; Expires=${date.toUTCString()}; Max-Age=${(config.expireControlCookieAfterDays || 365) * 24 * 60 * 60}; Path=/`;
   };
 
   const reloadOnSave = (forceReload) => {
@@ -233,6 +233,10 @@
   const runSetup = () => {
     config = getData("config");
     config.page = getData("page-config");
+
+    if (config?.controlCookieInvalidateNumber !== undefined && config?.controlCookieInvalidateNumber !== 0) {
+      config.controlCookie = `${config.controlCookie}${config.controlCookieInvalidateNumber}`;
+    }
 
     if (getCookieValue(config.controlCookie) !== "true") {
       bannerContainer = renderBanner();

--- a/src/main/resources/site/processors/cookie-panel.es6
+++ b/src/main/resources/site/processors/cookie-panel.es6
@@ -34,7 +34,9 @@ exports.responseProcessor = (req, res) => {
     saveLabel: siteConfig["cookie-panel-save-button-label"],
     readMoreLabel: siteConfig["cookie-panel-read-more-link-label"],
     readMoreLink: libs.portal.pageUrl({ id: siteConfig["cookie-panel-read-more-link"] }),
-    categories: categories
+    categories: categories,
+    expireControlCookieAfterDays: siteConfig["control-cookie-expire-after-days"],
+    controlCookieInvalidateNumber: siteConfig["control-cookie-invalidate-number"]
   };
 
   res.pageContributions.headEnd = libs.util.forceArray(res.pageContributions.headEnd);

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -108,6 +108,20 @@
         </field-set>
       </items>
     </field-set>
+    <field-set>
+      <label>Cookie panel cookie expiration</label>
+      <items>
+          <input name="control-cookie-expire-after-days" type="Long">
+              <label>How many days should pass before the user will get the Cookie Panel displayed again</label>
+              <default>365</default>
+          </input>
+          <input name="control-cookie-invalidate-number" type="Long">
+              <label>Number of times the Cookie Panel is forced displayed for the all users</label>
+              <help-text>This number is used to add a new control cookie, so it is possible to force display of the Cookie Panel to the user. Ex. if a category is edited or added.</help-text>
+              <default>0</default>
+          </input>
+      </items>
+    </field-set>
   </form>
   <processors>
     <response-processor name="cookie-panel" order="5"/>


### PR DESCRIPTION
The primary goal of this release is to enable the enforcement of new user consent and to allow customization of the duration before new consent is required for each app usage.

If you do not modify the value for "_How many days should pass before the user will get the Cookie Panel displayed again_" it will remain at 365 days, as was the default prior to this release.

When adjusting the "_Number of times the Cookie Panel is forced displayed for the all users_" the Cookie Panel will be shown to all users of the web page. This is particularly useful if you have added or modified a category.

Required XP version: 7.9.0