### PR TITLE
Prevent cookie panel text from being shown in Google search results

### DIFF
--- a/src/frontend/scripts/cookie-panel.es6
+++ b/src/frontend/scripts/cookie-panel.es6
@@ -203,6 +203,7 @@
     </div>`;
     const banner = document.createElement("div");
     banner.setAttribute("id", "cookie-panel-banner__wrapper");
+    banner.setAttribute("data-nosnippet", "");
 
     banner.innerHTML = html;
 


### PR DESCRIPTION
Add data-nosnippet attribute to prevent cookie panel text from being shown in Google search results.