### PR TITLE
feature/boueno-110: Lagt til secure and sameSite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,35 @@ other apps that they now can render their content.
 ## Features
 - Opt-in cookie consent for your users
 - Custom cookie groups/categories that users can enable/disable individually
+- Configurable cookie security attributes (Secure and SameSite)
 - Easy integration with other applications
 - Built-in light and dark themes to fit most site designs
 - Custom styling if you want something different from the built-in themes
 - Content Security Policy compatible
+
+## Configuring Cookie Security
+
+### Per-Cookie Attributes
+For each cookie in a category, you can configure:
+
+- **Secure**: When enabled, the cookie is only sent over HTTPS connections. On HTTP pages, the browser will not set the cookie.
+- **SameSite**: Controls when the cookie is sent with cross-site requests:
+  - `Lax` (default): Cookie is sent in same-site requests and top-level navigations. Provides CSRF protection while maintaining compatibility.
+  - `Strict`: Cookie is only sent in same-site requests. Most restrictive option.
+  - `None`: Cookie is sent in all contexts, including cross-site requests. **Requires `Secure=true`**. Use for cookies that need to work in cross-site contexts.
+  - Not set: Omits the attribute entirely (for legacy compatibility).
+
+### Control Cookie Attributes
+The internal control cookie used by Cookie Panel can also be configured with security attributes in the "Behavior" section:
+
+- **Secure**: Recommended to enable in production HTTPS environments.
+- **SameSite**: Defaults to `Lax` for security.
+
+### Important Notes
+- JavaScript-set cookies cannot use the `HttpOnly` attribute (server-only). If your security audit requires `HttpOnly`, you must use server-set cookies.
+- `SameSite=None` requires `Secure=true`. If you configure `SameSite=None` without `Secure`, the implementation will automatically enable `Secure`.
+- On HTTP (non-HTTPS) pages, cookies marked as `Secure` will not be persisted by the browser. This is expected behavior and not an error.
+- See [MDN: Practical implementation guides for cookies](https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Cookies) for more details.
 
 ## Customizing
 You can add CSS styling in your own applications to make the panels fit any design you want.

--- a/src/frontend/scripts/cookie-panel.es6
+++ b/src/frontend/scripts/cookie-panel.es6
@@ -30,11 +30,30 @@
     return b ? b.pop() : "";
   };
 
-  const setCookie = (name, value) => {
+  const setCookie = (name, value, options = {}) => {
     const date = new Date();
     const days = config.expireControlCookieAfterDays || 365;
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-    document.cookie = `${name}=${value || ""}; Expires=${date.toUTCString()}; Max-Age=${days * 24 * 60 * 60}; Path=/`;
+
+    let cookieString = `${name}=${value || ""}; Expires=${date.toUTCString()}; Max-Age=${days * 24 * 60 * 60}; Path=/`;
+
+    // Add Secure attribute if specified
+    if (options.secure === true) {
+      cookieString += "; Secure";
+    }
+
+    // Add SameSite attribute if specified
+    if (options.sameSite && options.sameSite !== "unset") {
+      // SameSite=None requires Secure, so enforce it
+      if (options.sameSite.toLowerCase() === "none" && !options.secure) {
+        cookieString += "; Secure";
+        // eslint-disable-next-line no-console
+        console.warn(`Cookie "${name}" has SameSite=None but Secure not set. Forcing Secure=true per browser requirement.`);
+      }
+      cookieString += `; SameSite=${options.sameSite.charAt(0).toUpperCase()}${options.sameSite.slice(1).toLowerCase()}`;
+    }
+
+    document.cookie = cookieString;
   };
 
   const reloadOnSave = (forceReload) => {
@@ -65,6 +84,16 @@
     });
   };
 
+  const getCookieOptions = (cookie) => ({
+    secure: cookie["cookie-secure"],
+    sameSite: cookie["cookie-samesite"]
+  });
+
+  const getControlCookieOptions = () => ({
+    secure: config.controlCookieSecure,
+    sameSite: config.controlCookieSameSite
+  });
+
   const saveCookieSettings = () => {
     let didDisable = false;
     forceArray(config.categories).forEach((category) => {
@@ -75,10 +104,14 @@
         if (!enabled && previousValue && previousValue !== value) {
           didDisable = true;
         }
-        setCookie(cookie["cookie-name"], value);
+        // Apply per-cookie secure and samesite attributes
+        const cookieOptions = getCookieOptions(cookie);
+        setCookie(cookie["cookie-name"], value, cookieOptions);
       });
     });
-    setCookie(config.controlCookie, "true");
+    // Set control cookie with configured attributes
+    const controlCookieOptions = getControlCookieOptions();
+    setCookie(config.controlCookie, "true", controlCookieOptions);
 
     // Only run consent callbacks if page will NOT reload, to avoid double execution
     if (!(config.page.reloadOnSave || didDisable)) {
@@ -91,10 +124,14 @@
   const acceptAllCookies = () => {
     forceArray(config.categories).forEach((category) => {
       forceArray(category.cookies).forEach((cookie) => {
-        setCookie(cookie["cookie-name"], cookie["cookie-value-accepted"]);
+        // Apply per-cookie secure and samesite attributes
+        const cookieOptions = getCookieOptions(cookie);
+        setCookie(cookie["cookie-name"], cookie["cookie-value-accepted"], cookieOptions);
       });
     });
-    setCookie(config.controlCookie, "true");
+    // Set control cookie with configured attributes
+    const controlCookieOptions = getControlCookieOptions();
+    setCookie(config.controlCookie, "true", controlCookieOptions);
 
     // Only run consent callbacks if page will NOT reload, to avoid double execution
     if (!config.page.reloadOnSave) {
@@ -107,10 +144,14 @@
   const rejectAllCookies = () => {
     forceArray(config.categories).forEach((category) => {
       forceArray(category.cookies).forEach((cookie) => {
-        setCookie(cookie["cookie-name"], cookie["cookie-value-rejected"]);
+        // Apply per-cookie secure and samesite attributes
+        const cookieOptions = getCookieOptions(cookie);
+        setCookie(cookie["cookie-name"], cookie["cookie-value-rejected"], cookieOptions);
       });
     });
-    setCookie(config.controlCookie, "true");
+    // Set control cookie with configured attributes
+    const controlCookieOptions = getControlCookieOptions();
+    setCookie(config.controlCookie, "true", controlCookieOptions);
 
     reloadOnSave();
   };

--- a/src/frontend/scripts/cookie-panel.es6
+++ b/src/frontend/scripts/cookie-panel.es6
@@ -44,11 +44,9 @@
 
     // Add SameSite attribute if specified
     if (options.sameSite && options.sameSite !== "unset") {
-      // SameSite=None requires Secure, so enforce it
+      // SameSite=None requires Secure — enforce silently as safety net
       if (options.sameSite.toLowerCase() === "none" && !options.secure) {
         cookieString += "; Secure";
-        // eslint-disable-next-line no-console
-        console.warn(`Cookie "${name}" has SameSite=None but Secure not set. Forcing Secure=true per browser requirement.`);
       }
       cookieString += `; SameSite=${options.sameSite.charAt(0).toUpperCase()}${options.sameSite.slice(1).toLowerCase()}`;
     }

--- a/src/main/resources/lib/util.es6
+++ b/src/main/resources/lib/util.es6
@@ -16,6 +16,24 @@ exports.controlCookieName = controlCookieName;
 const getCategoryId = category => `cookie-panel-${libs.common.sanitize(category.title)}`;
 exports.getCategoryId = getCategoryId;
 
+const normalizeSameSite = (value) => {
+  const samesite = (value || "lax").toLowerCase();
+  return ["unset", "none", "lax", "strict"].indexOf(samesite) !== -1 ? samesite : "lax";
+};
+exports.normalizeSameSite = normalizeSameSite;
+
+const normalizeCookieAttributes = (cookie) => {
+  const normalized = { ...cookie };
+  
+  // Normalize secure attribute to boolean
+  normalized["cookie-secure"] = cookie["cookie-secure"] === true || cookie["cookie-secure"] === "true";
+  
+  // Normalize samesite to one of: unset, lax, strict, none
+  normalized["cookie-samesite"] = normalizeSameSite(cookie["cookie-samesite"]);
+  
+  return normalized;
+};
+
 const getCookieCategories = siteConfig => [{
   title: siteConfig["cookie-panel-required-title"],
   description: siteConfig["cookie-panel-required-description"],
@@ -26,6 +44,8 @@ const getCookieCategories = siteConfig => [{
 ].map((category) => {
   const c = category;
   c.id = getCategoryId(c);
+  // Normalize cookie attributes for each cookie in the category
+  c.cookies = forceArray(c.cookies).map(cookie => normalizeCookieAttributes(cookie));
   return c;
 });
 exports.getCookieCategories = getCookieCategories;

--- a/src/main/resources/lib/util.es6
+++ b/src/main/resources/lib/util.es6
@@ -31,6 +31,11 @@ const normalizeCookieAttributes = (cookie) => {
   // Normalize samesite to one of: unset, lax, strict, none
   normalized["cookie-samesite"] = normalizeSameSite(cookie["cookie-samesite"]);
   
+  // SameSite=None requires Secure per browser spec
+  if (normalized["cookie-samesite"] === "none") {
+    normalized["cookie-secure"] = true;
+  }
+  
   return normalized;
 };
 

--- a/src/main/resources/site/processors/cookie-panel.es6
+++ b/src/main/resources/site/processors/cookie-panel.es6
@@ -37,7 +37,9 @@ exports.responseProcessor = (req, res) => {
     readMoreLink: libs.portal.pageUrl({ id: siteConfig["cookie-panel-read-more-link"] }),
     categories: categories,
     expireControlCookieAfterDays: siteConfig["control-cookie-expire-after-days"],
-    controlCookieInvalidateNumber: siteConfig["control-cookie-invalidate-number"]
+    controlCookieInvalidateNumber: siteConfig["control-cookie-invalidate-number"],
+    controlCookieSecure: siteConfig["control-cookie-secure"] === true || siteConfig["control-cookie-secure"] === "true",
+    controlCookieSameSite: libs.util.normalizeSameSite(siteConfig["control-cookie-samesite"])
   };
 
   res.pageContributions.headEnd = libs.util.forceArray(res.pageContributions.headEnd);

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -73,6 +73,31 @@
             <alignment>left</alignment>
           </config>
         </input>
+        <field-set>
+          <label>Control cookie attributes</label>
+          <help-text>Configure security attributes for the internal cookie panel control cookie.</help-text>
+          <items>
+            <input name="control-cookie-secure" type="CheckBox">
+              <label>Secure (send only over HTTPS)</label>
+              <help-text>Enable to mark the control cookie as Secure. Recommended for production HTTPS sites.</help-text>
+              <default>checked</default>
+              <config>
+                <alignment>left</alignment>
+              </config>
+            </input>
+            <input name="control-cookie-samesite" type="ComboBox">
+              <label>SameSite attribute for control cookie</label>
+              <help-text>Controls when the control cookie is sent with cross-site requests. Default is Lax for security.</help-text>
+              <occurrences minimum="1" maximum="1" />
+              <config>
+                <option value="lax">Lax (default, recommended)</option>
+                <option value="strict">Strict (most restrictive)</option>
+                <option value="none">None (requires Secure=true)</option>
+              </config>
+              <default>lax</default>
+            </input>
+          </items>
+        </field-set>
       </items>
     </field-set>
 
@@ -120,6 +145,26 @@
                     </input>
                     <input name="cookie-value-rejected" type="TextLine">
                       <label>Cookie value: Rejected</label>
+                    </input>
+                    <input name="cookie-secure" type="CheckBox">
+                      <label>Secure (send only over HTTPS)</label>
+                      <help-text>Enable to mark this cookie as Secure. The browser will only send this cookie over HTTPS connections. On HTTP, the cookie will not be set by the browser.</help-text>
+                      <default>unchecked</default>
+                      <config>
+                        <alignment>left</alignment>
+                      </config>
+                    </input>
+                    <input name="cookie-samesite" type="ComboBox">
+                      <label>SameSite attribute</label>
+                      <help-text>Controls when the cookie is sent with cross-site requests. SameSite=None requires Secure=true. Learn more: https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Cookies</help-text>
+                      <occurrences minimum="0" maximum="1" />
+                      <config>
+                        <option value="unset">Not set (omit attribute)</option>
+                        <option value="lax">Lax (default for modern browsers)</option>
+                        <option value="strict">Strict (most restrictive)</option>
+                        <option value="none">None (requires Secure=true)</option>
+                      </config>
+                      <default>lax</default>
                     </input>
                   </items>
                 </item-set>


### PR DESCRIPTION
[BOUENO-110](https://bouvet.atlassian.net/browse/BOUENO-110) 

Adds configurable Secure and SameSite attributes for both per-category cookies and the internal control cookie.

1. Default behavior (no config changes)

- Open site, accept cookies → verify cookies are set with SameSite=Lax
- Control cookie should have Secure and SameSite=Lax
- Inspect cookies in DevTools → Application → Cookies

2. Per-cookie Secure flag

- Configure a category cookie with Secure enabled
- Accept cookies on an HTTPS page → cookie should appear with the Secure flag
- If testable on HTTP: cookie should not be persisted by the browser

3. Per-cookie SameSite options

- Set a cookie to Strict → verify SameSite=Strict in DevTools
- Set a cookie to None without Secure checked → verify that the cookie still gets the Secure flag (server-side enforcement).
- Set a cookie to None with Secure → verify both attributes present.
- Set a cookie to Not set (omit attribute) → verify no SameSite attribute on the cookie string

4. Control cookie attributes

- Change control cookie to Strict → verify it appears with SameSite=Strict
- Uncheck Secure on control cookie → verify Secure flag is absent