### PR TITLE
feature/boueno-148:  WCAG change h2 to h1

### DIFF
--- a/src/frontend/scripts/cookie-panel.es6
+++ b/src/frontend/scripts/cookie-panel.es6
@@ -122,7 +122,7 @@
             <input ${(category.default ? "checked disabled" : "")} type="checkbox" id="${category.id}" aria-labelledby="${category.id}-title">
             <span class="cookie-panel-switch__toggle"></span>
           </label>
-          <h3 id="${category.id}-title">${category.title || ""}</h3>
+          <h2 id="${category.id}-title">${category.title || ""}</h2>
         </div>
         <p>${category.description || ""}</p>
         <hr/>

--- a/src/frontend/scripts/cookie-panel.es6
+++ b/src/frontend/scripts/cookie-panel.es6
@@ -142,7 +142,7 @@
     const html = `
       <div role="dialog" class="cookie-panel-settings ${config.theme}" id="cookie-panel-settings" aria-labelledby="cookie-panel-settings-title">
         <div class="cookie-panel-settings__inner">
-          <h2 id="cookie-panel-settings-title">${config.title}</h2>
+          <h1 id="cookie-panel-settings-title">${config.title}</h1>
           <div class="cookie-panel-settings__categories">${renderCategories(config.categories)}</div>
           <div class="cookie-panel-settings__buttons">
           ${config.buttonOrder === "accept-left"
@@ -197,7 +197,7 @@
 
     const html = `<div class="cookie-panel-banner ${config.theme}" id="cookie-panel-banner">
     <div class="cookie-panel-banner__inner">
-      ${config.title ? `<h2 class="cookie-panel-banner__title">${config.title}</h2>` : ""}
+      ${config.title ? `<h1 class="cookie-panel-banner__title">${config.title}</h1>` : ""}
       ${config.description ? `<p class="cookie-panel-banner__description">${config.description}</p>` : ""}
       <div class="cookie-panel-banner__buttons">
         ${config.buttonOrder === "accept-left"

--- a/src/frontend/styles/main.scss
+++ b/src/frontend/styles/main.scss
@@ -87,6 +87,10 @@
   width: 100%;
   bottom: 0;
 
+  h1 {
+    overflow-wrap: break-word;
+  }
+
   &.dark {
     background-color: #333;
     color: white;


### PR DESCRIPTION
[BOUENO-148](https://bouvet.atlassian.net/browse/BOUENO-148) Cookie Panel App - Siteimprove issue:

Oppdatert h2 tag til h1

Tok da og oppdaterte h3 til h2 også

Dette er en breaking change for styling hvor de som bruker custom styling for sin Cookie panel, må ha i breaking change i release note. h2 -> h1 og h3 -> h2

fks Forsvaret har .cookie-panel-settings__inner css for h2 tags, ikke h1 og h2 for h3